### PR TITLE
Fix URL to autoprotocol main page in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Autoprotocol-Core
 
-This repository contains a collection of scripts that use the [autoprotocol-python](http://github.com/autoprotocol/autoprotocol-python) library to generate protocols in [Autoprotocol](https://www.autoprotocol.org), a standard way to express experiments in life science.
+This repository contains a collection of scripts that use the [autoprotocol-python](http://github.com/autoprotocol/autoprotocol-python) library to generate protocols in [Autoprotocol](http://www.autoprotocol.org), a standard way to express experiments in life science.
 
 ## Installation
 


### PR DESCRIPTION
Incredibly minor but HTTPS does not seem to be working for https://www.autoprotocol.org so changed to working HTTP URL in README